### PR TITLE
Refactor tests to extract mock data loading utility

### DIFF
--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -1,23 +1,16 @@
-import json
-import os
 import pytest
 
 from unittest.mock import Mock
+
 from pytrello2.models.board import Board
 from pytrello2.board import BoardManager
+
+from .utils import load_mock_data
+
 
 # Constants for mock data file paths
 BOARD_MOCK_DATA = "board.json"
 BOARDS_MOCK_DATA = "boards.json"
-
-
-# Utility function to load mock data from a file
-def load_mock_data(file_name):
-    current_dir = os.path.dirname(os.path.realpath(__file__))
-    data_dir = os.path.join(current_dir, "data")
-    file_path = os.path.join(data_dir, file_name)
-    with open(file_path, "r") as file:
-        return json.load(file)
 
 
 # Fixture for the mock HTTP client

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -1,22 +1,15 @@
-import json
-import os
 import pytest
 
 from unittest.mock import Mock
+
 from pytrello2.models.card import Card
 from pytrello2.card import CardManager
 
+from .utils import load_mock_data
+
+
 # Constants for mock data file paths
 CARD_MOCK_DATA = "card.json"
-
-
-# Utility function to load mock data from a file
-def load_mock_data(file_name):
-    current_dir = os.path.dirname(os.path.realpath(__file__))
-    data_dir = os.path.join(current_dir, "data")
-    file_path = os.path.join(data_dir, file_name)
-    with open(file_path, "r") as file:
-        return json.load(file)
 
 
 # Fixture for the mock HTTP client

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -32,6 +32,7 @@ def test_get_card(mock_http_client):
     mock_http_client.get.assert_called_once_with("cards/test_card_id")
 
 
+# Test for create_card method
 def test_create_card(mock_http_client):
     card_data = load_mock_data(CARD_MOCK_DATA)
     mock_http_client.post.return_value = card_data
@@ -43,6 +44,7 @@ def test_create_card(mock_http_client):
     assert card.id == card_data["id"]
 
 
+# Test for delete_card method
 def test_delete_card(mock_http_client):
     card_data = load_mock_data(CARD_MOCK_DATA)
     mock_http_client.delete.return_value = card_data
@@ -53,6 +55,7 @@ def test_delete_card(mock_http_client):
     assert isinstance(card, Card)
 
 
+# Test for update_card method
 def test_update_card(mock_http_client):
     card_data = load_mock_data(CARD_MOCK_DATA)
     mock_http_client.put.return_value = card_data

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,6 +2,7 @@ import pytest
 import requests
 
 from unittest.mock import patch, Mock
+
 from pytrello2.client import HttpClient
 from pytrello2.exceptions import TrelloAPIException
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -31,7 +31,7 @@ def test_get_list(mock_http_client):
     assert list_type.name == list_data["name"]
 
 
-# Test for get all cards method
+# Test for get_cards_on_list method
 def test_get_cards_on_list(mock_http_client):
     list_data = load_mock_data(LIST_MOCK_DATA)
     mock_http_client.get.return_value = list_data
@@ -44,7 +44,7 @@ def test_get_cards_on_list(mock_http_client):
     assert list_type.name == list_data["name"]
 
 
-# Test for create list method
+# Test for create_list method
 def test_create_list(mock_http_client):
     list_data = load_mock_data(LIST_MOCK_DATA)
     mock_http_client.post.return_value = list_data
@@ -57,7 +57,7 @@ def test_create_list(mock_http_client):
     assert list_type.name == list_data["name"]
 
 
-# Test for update list method
+# Test for update_list method
 def test_update_list(mock_http_client):
     list_data = load_mock_data(LIST_MOCK_DATA)
     mock_http_client.put.return_value = list_data
@@ -69,7 +69,7 @@ def test_update_list(mock_http_client):
     assert list_type.id == list_data["id"]
 
 
-# Test for archive list method
+# Test for archive_list method
 def test_archive_list(mock_http_client):
     list_data = load_mock_data(LIST_MOCK_DATA)
     mock_http_client.post.return_value = list_data

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,22 +1,15 @@
-import json
-import os
 import pytest
 
 from unittest.mock import Mock
+
 from pytrello2.models.list import List
 from pytrello2.list import ListManager
 
+from .utils import load_mock_data
+
+
 # Constants for mock data file paths
 LIST_MOCK_DATA = "list.json"
-
-
-# Utility function to load mock data from a file
-def load_mock_data(file_name):
-    current_dir = os.path.dirname(os.path.realpath(__file__))
-    data_dir = os.path.join(current_dir, "data")
-    file_path = os.path.join(data_dir, file_name)
-    with open(file_path, "r") as file:
-        return json.load(file)
 
 
 # Fixture for the mock HTTP client

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,24 +1,14 @@
-import json
-import os
-
 from pytrello2.models.board import Board
 from pytrello2.models.card import Card
 from pytrello2.models.list import List
+
+from .utils import load_mock_data
 
 
 # Constants for mock data file paths
 BOARD_MOCK_DATA = "board.json"
 CARD_MOCK_DATA = "card.json"
 LIST_MOCK_DATA = "list.json"
-
-
-# Utility function to load mock data from a file
-def load_mock_data(file_name):
-    current_dir = os.path.dirname(__file__)
-    data_dir = os.path.join(current_dir, "data")
-    file_path = os.path.join(data_dir, file_name)
-    with open(file_path, "r") as file:
-        return json.load(file)
 
 
 # Test for board model

--- a/tests/test_trello.py
+++ b/tests/test_trello.py
@@ -1,6 +1,9 @@
 from pytrello2 import TrelloClient
 from pytrello2.client import HttpClient
 from pytrello2.board import BoardManager
+from pytrello2.card import CardManager
+from pytrello2.list import ListManager
+
 
 TEST_API_KEY = "test_api_key"
 TEST_TOKEN = "test_token"
@@ -12,6 +15,8 @@ def test_trello_client():
 
     assert isinstance(client.http_client, HttpClient)
     assert isinstance(client.board, BoardManager)
+    assert isinstance(client.card, CardManager)
+    assert isinstance(client.list, ListManager)
 
     assert client.http_client.api_key == TEST_API_KEY
     assert client.http_client.token == TEST_TOKEN

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,15 @@
+import os
+import json
+
+
+def load_mock_data(file_name):
+    """
+    Load mock data from a JSON file
+    :param file_name: Name of the JSON file
+    :return: JSON data
+    """
+    current_dir = os.path.dirname(os.path.realpath(__file__))
+    data_dir = os.path.join(current_dir, "data")
+    file_path = os.path.join(data_dir, file_name)
+    with open(file_path, "r") as file:
+        return json.load(file)


### PR DESCRIPTION
This PR refactors the tests by extracting the common mock data loading logic to a utils module. 

The `load_mock_data` function is now defined in `tests/utils.py` and imported where needed. This avoids having duplicate copies of this code across multiple test modules.

No functionality changes, just code structure/organization improvements for test code.